### PR TITLE
feat: Add endpoints for starting / ending a round using commands

### DIFF
--- a/game-service/src/database/migrations/Migration20220405143646.ts
+++ b/game-service/src/database/migrations/Migration20220405143646.ts
@@ -1,0 +1,14 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20220405143646 extends Migration {
+  async up(): Promise<void> {
+    this.addSql(
+      'alter table "round" add column "started_at" timestamptz(0) null, add column "ended_at" timestamptz(0) null;',
+    );
+  }
+
+  async down(): Promise<void> {
+    this.addSql('alter table "round" drop column "started_at";');
+    this.addSql('alter table "round" drop column "ended_at";');
+  }
+}

--- a/game-service/src/lobby/lobby.controller.ts
+++ b/game-service/src/lobby/lobby.controller.ts
@@ -7,13 +7,14 @@ import {
   SerializeOptions,
 } from '@nestjs/common';
 import { LobbyService } from './lobby.service';
-import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import {
   LobbyResponseDto,
   responseWithCurrentRound,
   CreateLobbyDto,
 } from './dto';
 
+@ApiTags('Lobby')
 @Controller('lobbies')
 export class LobbyController {
   constructor(private readonly lobbyService: LobbyService) {}

--- a/game-service/src/lobby/lobby.service.ts
+++ b/game-service/src/lobby/lobby.service.ts
@@ -5,6 +5,8 @@ import { Lobby } from './lobby.entity';
 import { CreateLobbyDto } from './dto';
 import { Round } from '../round/round.entity';
 
+type INCLUDES = 'currentRound' | 'rounds';
+
 @Injectable()
 export class LobbyService {
   constructor(
@@ -44,14 +46,15 @@ export class LobbyService {
   /**
    * Retrieve a specific lobby from the database.
    * @param id is the id of the lobby.
+   * @param populate are the relations that should be present.
    * @returns the lobby including the current round.
    * @exception NotFoundException if the given id does not match a lobby.
    */
-  async getById(id: string): Promise<Lobby> {
-    const lobby = await this.lobbyRepository.findOne(
-      { id: id },
-      { populate: ['currentRound'] },
-    );
+  async getById(
+    id: string,
+    populate: INCLUDES[] = ['currentRound'],
+  ): Promise<Lobby> {
+    const lobby = await this.lobbyRepository.findOne({ id: id }, { populate });
 
     if (!lobby) throw new NotFoundException('Lobby not found');
 

--- a/game-service/src/payer/player.controller.ts
+++ b/game-service/src/payer/player.controller.ts
@@ -3,7 +3,7 @@ import { PlayerService } from './player.service';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { PlayerResponseDto } from './dto/player-response.dto';
 
-@ApiTags('Lobby')
+@ApiTags('Player')
 @Controller('lobbies/:lobby_id/players')
 export class PlayerController {
   constructor(private readonly playerService: PlayerService) {}

--- a/game-service/src/round/dto/round-response.dto.ts
+++ b/game-service/src/round/dto/round-response.dto.ts
@@ -24,6 +24,14 @@ export class RoundResponseDto {
   @Expose()
   lobbyId: string;
 
+  @ApiProperty()
+  @Expose()
+  startedAt: Date;
+
+  @ApiProperty()
+  @Expose()
+  endedAt: Date;
+
   constructor(partial: Partial<Round>) {
     Object.assign(this, partial);
     this.lobbyId = partial.lobby.id;

--- a/game-service/src/round/round.command.ts
+++ b/game-service/src/round/round.command.ts
@@ -1,0 +1,66 @@
+import { RoundService } from './round.service';
+import { Injectable } from '@nestjs/common';
+import { SocketService } from '../lobby/socket.service';
+import { CreateRoundDto } from './dto';
+import { LobbyService } from '../lobby/lobby.service';
+
+@Injectable()
+export class RoundCommand {
+  constructor(
+    private readonly roundService: RoundService,
+    private readonly socketService: SocketService,
+    private readonly lobbyService: LobbyService,
+  ) {}
+
+  /**
+   * This method will handle the logic for starting a round.
+   * @param id is the id of the round to start.
+   * @exception NotFoundException if the round was not found.
+   * @exception BadRequestException if the round already started.
+   */
+  async startRound(id: string): Promise<void> {
+    const round = await this.roundService.findRound(id);
+
+    await this.roundService.startRound(round);
+
+    this.socketService.send(round.lobby.id, 'round.started', round);
+  }
+
+  /**
+   * This method will handle the logic for starting a round.
+   * @param id is the id of the round to end.
+   * @exception NotFoundException if the round was not found.
+   * @exception BadRequestException if the round already ended.
+   */
+  async endRound(id: string): Promise<void> {
+    const round = await this.roundService.findRound(id);
+
+    await this.roundService.endRound(round);
+
+    this.socketService.send(round.lobby.id, 'round.ended', round);
+  }
+
+  /**
+   * Creates a new round for an existing lobby, if there is no round
+   * already existing or running.
+   * @param lobbyId is the id of the lobby.
+   * @param round are the parameters used to create the new lobby.
+   * @exception NotFoundException if the lobby was not found.
+   * @exception BadRequestException if the lobby already has a round present / active.
+   */
+  async createNewRound(lobbyId: string, round: CreateRoundDto) {
+    const lobby = await this.lobbyService.getById(lobbyId, [
+      'currentRound',
+      'rounds',
+    ]);
+
+    const newRound = await this.roundService.createNewRoundForLobby(
+      lobby,
+      round,
+    );
+
+    this.socketService.send(lobby.id, 'round.created', newRound);
+
+    return newRound;
+  }
+}

--- a/game-service/src/round/round.controller.ts
+++ b/game-service/src/round/round.controller.ts
@@ -1,15 +1,26 @@
-import { Body, Controller, Get, Param, Post } from '@nestjs/common';
-import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { Body, Controller, Get, Param, Post, Put } from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiCreatedResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
 import { RoundService } from './round.service';
 import { RoundResponseDto, CreateRoundDto } from './dto';
+import { RoundCommand } from './round.command';
 
+@ApiTags('Round')
 @Controller('lobbies/:lobby_id/rounds')
 export class RoundController {
-  constructor(private readonly roundService: RoundService) {}
+  constructor(
+    private readonly roundService: RoundService,
+    private readonly roundCommand: RoundCommand,
+  ) {}
 
   @ApiOperation({ summary: 'Get all rounds' })
-  @ApiResponse({
-    status: 200,
+  @ApiOkResponse({
     description: 'Returns all rounds of a lobby',
     type: [RoundResponseDto],
   })
@@ -17,27 +28,46 @@ export class RoundController {
   async getRounds(
     @Param('lobby_id') lobby_id: string,
   ): Promise<RoundResponseDto[]> {
-    const rounds = await this.roundService.getAllForLobby(lobby_id);
-    return rounds.map((round) => new RoundResponseDto(round));
+    return (await this.roundService.getAllForLobby(lobby_id)).map(
+      (round) => new RoundResponseDto(round),
+    );
   }
 
   @ApiOperation({ summary: 'Create a new round' })
-  @ApiResponse({
-    status: 201,
-    description: 'Round created',
-    type: RoundResponseDto,
+  @ApiCreatedResponse({ description: 'Round created', type: RoundResponseDto })
+  @ApiBadRequestResponse({
+    description: 'Invalid round or a round is already active / present',
   })
-  @ApiResponse({ status: 400, description: 'Invalid round' })
-  @ApiResponse({ status: 404, description: 'Lobby was not found' })
+  @ApiNotFoundResponse({ description: 'Lobby was not found' })
   @Post()
   async createRound(
     @Param('lobby_id') lobby_id: string,
     @Body() params: CreateRoundDto,
   ): Promise<RoundResponseDto> {
-    const round = await this.roundService.createNewRoundForLobby(
-      lobby_id,
-      params,
+    return new RoundResponseDto(
+      await this.roundCommand.createNewRound(lobby_id, params),
     );
-    return new RoundResponseDto(round);
+  }
+
+  @ApiOperation({ summary: 'Start a round' })
+  @ApiOkResponse({ description: 'Successfully started the round' })
+  @ApiBadRequestResponse({
+    description: 'Could not start the round because it already started',
+  })
+  @ApiNotFoundResponse({ description: 'Could not find the requested round' })
+  @Put(':id/start')
+  async startRound(@Param('id') id: string) {
+    return this.roundCommand.startRound(id);
+  }
+
+  @ApiOperation({ summary: 'End a round' })
+  @ApiOkResponse({ description: 'Successfully ended the round' })
+  @ApiBadRequestResponse({
+    description: 'Could not end the round because it is not active',
+  })
+  @ApiNotFoundResponse({ description: 'Could not find the requested round' })
+  @Put(':id/end')
+  async endRound(@Param('id') id: string) {
+    return this.roundCommand.endRound(id);
   }
 }

--- a/game-service/src/round/round.entity.ts
+++ b/game-service/src/round/round.entity.ts
@@ -15,10 +15,16 @@ import { SelectedCards } from '../payer/selectedCards.entity';
 @Entity()
 export class Round extends BaseEntity {
   @Property({ type: ArrayType, nullable: false })
-  cards!: string[];
+  cards: string[] = [];
 
   @ManyToOne({ entity: () => Lobby, wrappedReference: true })
   lobby!: Lobby;
+
+  @Property({ nullable: true })
+  startedAt?: Date;
+
+  @Property({ nullable: true })
+  endedAt?: Date;
 
   @OneToOne(() => Lobby, (lobby) => lobby.currentRound, {
     hidden: true,
@@ -28,4 +34,16 @@ export class Round extends BaseEntity {
 
   @OneToMany({ entity: () => SelectedCards, mappedBy: 'round', hidden: true })
   selectedCards = new Collection<SelectedCards>(this);
+
+  public hasStarted(): boolean {
+    return !!this.startedAt;
+  }
+
+  public hasEnded(): boolean {
+    return !!this.endedAt;
+  }
+
+  public isActive(): boolean {
+    return this.hasStarted() && !this.hasEnded();
+  }
 }

--- a/game-service/src/round/round.module.ts
+++ b/game-service/src/round/round.module.ts
@@ -4,10 +4,13 @@ import { RoundService } from './round.service';
 import { MikroOrmModule } from '@mikro-orm/nestjs';
 import { Round } from './round.entity';
 import { Lobby } from '../lobby/lobby.entity';
+import { RoundCommand } from './round.command';
+import { SocketService } from '../lobby/socket.service';
+import { LobbyService } from '../lobby/lobby.service';
 
 @Module({
   imports: [MikroOrmModule.forFeature([Round, Lobby])],
   controllers: [RoundController],
-  providers: [RoundService],
+  providers: [RoundService, RoundCommand, SocketService, LobbyService],
 })
 export class RoundModule {}

--- a/game-service/src/test/factories/lobby.ts
+++ b/game-service/src/test/factories/lobby.ts
@@ -3,6 +3,7 @@ import { faker } from '@faker-js/faker';
 import { Lobby } from '../../lobby/lobby.entity';
 import { generateGameCode } from '@helpers/index';
 import { MikroORM } from '@mikro-orm/core';
+import { Round } from '../../round/round.entity';
 
 export const lobby = (data: Partial<Lobby> = {}, orm?: MikroORM): Lobby => {
   let lobby = {
@@ -33,4 +34,36 @@ export const createLobbies = (
   }
 
   return result;
+};
+
+export const lobbyWithRound = (
+  data: Partial<Lobby> = {},
+  orm: MikroORM,
+  started = true,
+  ended = false,
+): Lobby => {
+  const lobby: Lobby = orm.em.create(Lobby, {
+    id: v4(),
+    code: generateGameCode(),
+    createdAt: faker.date.recent(),
+    updatedAt: faker.date.recent(),
+    title: faker.lorem.sentence(5),
+    ...data,
+  });
+
+  const activeRound = orm.em.create(Round, {
+    id: v4(),
+    createdAt: faker.date.recent(),
+    updatedAt: faker.date.recent(),
+    startedAt: started ? faker.date.recent() : null,
+    endedAt: ended ? faker.date.recent() : null,
+  });
+
+  lobby.rounds.add(activeRound);
+  orm.em.persistAndFlush(lobby);
+
+  lobby.currentRound = activeRound;
+  orm.em.persistAndFlush(lobby);
+
+  return lobby;
 };


### PR DESCRIPTION
It also implements logic for preventing to add a new round, if one is currently active or ready.

@jellehuibregtse this is an example on how commands could be used to seperate the service's domain logic from the infrastructure logic (websocket events / kafka events / others...).