### PR TITLE
feat: Add display for selected cards.

### DIFF
--- a/game-service/src/auth/jwt.decorator.ts
+++ b/game-service/src/auth/jwt.decorator.ts
@@ -1,0 +1,16 @@
+import {
+  createParamDecorator,
+  ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { JwtPayloadDto } from './dto/jwt-payload.dto';
+
+export const JWT = createParamDecorator(
+  (_data: unknown, context: ExecutionContext): JwtPayloadDto => {
+    if (context.getType() === 'http') {
+      return context.switchToHttp().getRequest().user;
+    }
+
+    throw new UnauthorizedException();
+  },
+);

--- a/game-service/src/selectedCards/selectedCards.controller.spec.ts
+++ b/game-service/src/selectedCards/selectedCards.controller.spec.ts
@@ -113,7 +113,7 @@ describe('SelectedCardsController', () => {
         orm,
       );
       const req = await controller.addCardToLiked(
-        p.id,
+        { playerId: p.id },
         l.currentRound.id,
         newCard,
       );
@@ -151,7 +151,7 @@ describe('SelectedCardsController', () => {
 
       expect(
         await controller.removeCardFromLiked(
-          p.id,
+          { playerId: p.id },
           l.currentRound.id,
           removedCard,
         ),
@@ -182,7 +182,10 @@ describe('SelectedCardsController', () => {
           { player: p, round: l.currentRound, cards: [...playerCards, v4()] },
           orm,
         );
-        const req = await controller.finishedSelecting(p.id, l.currentRound.id);
+        const req = await controller.finishedSelecting(
+          { playerId: p.id },
+          l.currentRound.id,
+        );
 
         expect({ cards: req.cards }).toMatchObject({
           cards: playerSelectedCards.cards,
@@ -200,7 +203,7 @@ describe('SelectedCardsController', () => {
         );
 
         expect(
-          controller.finishedSelecting(p.id, l.currentRound.id),
+          controller.finishedSelecting({ playerId: p.id }, l.currentRound.id),
         ).rejects.toThrow(Error);
       });
 
@@ -217,7 +220,7 @@ describe('SelectedCardsController', () => {
         );
 
         await expect(
-          controller.finishedSelecting(p.id, l.currentRound.id),
+          controller.finishedSelecting({ playerId: p.id }, l.currentRound.id),
         ).rejects.toThrow(Error);
       });
     });

--- a/web/src/api/models/SelectedCards.ts
+++ b/web/src/api/models/SelectedCards.ts
@@ -1,0 +1,8 @@
+export interface SelectedCards {
+  id: string;
+  roundId: string;
+  playerId: string;
+  cards: string[];
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/web/src/api/models/index.ts
+++ b/web/src/api/models/index.ts
@@ -1,3 +1,4 @@
 export * from './Lobby';
 export * from './Player';
 export * from './Round';
+export * from './SelectedCards';

--- a/web/src/api/requests/selectedCards.ts
+++ b/web/src/api/requests/selectedCards.ts
@@ -1,0 +1,46 @@
+import { SelectedCards } from '../models';
+
+export const useLikeCard = (roundId: string) => {
+  return async (cardId: string): Promise<SelectedCards> => {
+    const res = await fetch(
+      `/api/lobbies/rounds/${roundId}/select-cards/like/${cardId}`,
+      {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem('accessTokenAtos')}`
+        }
+      }
+    );
+    return await res.json();
+  };
+};
+
+export const useUnLikeCard = (roundId: string) => {
+  return async (cardId: string): Promise<SelectedCards> => {
+    const res = await fetch(
+      `/api/lobbies/rounds/${roundId}/select-cards/unlike/${cardId}`,
+      {
+        method: 'DELETE',
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem('accessTokenAtos')}`
+        }
+      }
+    );
+    return await res.json();
+  };
+};
+
+export const useFinishSelecting = (roundId: string) => {
+  return async (): Promise<SelectedCards> => {
+    const res = await fetch(
+      `/api/lobbies/rounds/${roundId}/select-cards/finish`,
+      {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem('accessTokenAtos')}`
+        }
+      }
+    );
+    return await res.json();
+  };
+};

--- a/web/src/components/PlayerAvatar/PlayerView.tsx
+++ b/web/src/components/PlayerAvatar/PlayerView.tsx
@@ -1,8 +1,15 @@
 import { PlayerAvatar } from './PlayerAvatar';
-import { Box, Group, Text, useMantineTheme } from '@mantine/core';
-import { Player } from '../../api/models/Player';
+import { Box, Group, List, Text, useMantineTheme } from '@mantine/core';
+import { Player } from '../../api/models';
+import { DisplayCard } from '../../pages/admin/GameView/components/DisplayCard';
 
-export function PlayerView({ player }: { player: Player }) {
+export function PlayerView({
+  player,
+  cardIds
+}: {
+  player: Player;
+  cardIds?: string[];
+}) {
   const theme = useMantineTheme();
 
   return (
@@ -17,6 +24,14 @@ export function PlayerView({ player }: { player: Player }) {
           {player.name}
         </Text>
       </Box>
+
+      {cardIds && (
+        <List style={{ marginTop: 12, flexGrow: 1 }}>
+          {cardIds.map((cardId) => {
+            return <DisplayCard id={cardId} key={cardId} />;
+          })}
+        </List>
+      )}
     </Group>
   );
 }

--- a/web/src/components/PlayerGameView/PlayerGameView.tsx
+++ b/web/src/components/PlayerGameView/PlayerGameView.tsx
@@ -1,39 +1,61 @@
-import { Container, Group, Button, Text, Drawer, Card } from '@mantine/core';
+import { Container, Group, Button, Text } from '@mantine/core';
 import CardTemplate from '../Card/Card';
 import { FaGrinAlt, FaRegFrown } from 'react-icons/fa';
 import { useContext, useState } from 'react';
 import { PlayerGameContext } from '../../hooks/usePlayerGameContext';
 import styles from './PlayerGameView.module.css';
 import DrawerComponent from '../Drawer/Drawer';
+import {
+  useFinishSelecting,
+  useLikeCard,
+  useUnLikeCard
+} from '../../api/requests/selectedCards';
+import { SocketContext } from '../../hooks/useSocketContext';
+import { Card } from '../../api/requests/card';
 
 function PlayerGameView2() {
   const { carouselCards, selectedCards, setSelectedCards } =
     useContext(PlayerGameContext);
+  const { state } = useContext(SocketContext);
   const [index, setIndex] = useState(0);
+  const likeCard = useLikeCard(state?.currentRound.id || '');
+  const unLikeCard = useUnLikeCard(state?.currentRound.id || '');
+  const finishSelecting = useFinishSelecting(state?.currentRound.id || '');
 
   const renderedCards = carouselCards.filter(
     (card: any) => !selectedCards.includes(card)
   );
+
   function dislike() {
     setIndex(index + 1);
   }
   function like() {
-    if (renderedCards && index < renderedCards.length) {
-      setSelectedCards((selectedCards: any) => [
-        ...selectedCards,
-        renderedCards[index]
-      ]);
-    }
+    likeCard(renderedCards[index].id).then(() => {
+      if (renderedCards && index < renderedCards.length) {
+        setSelectedCards((selectedCards: any) => [
+          ...selectedCards,
+          renderedCards[index]
+        ]);
+      }
+    });
   }
 
   function removeDrawerCard(deletedCardText: string) {
-    setSelectedCards((selectedCards: any) => {
-      return selectedCards.filter((card: any) => card.text !== deletedCardText);
+    const id = selectedCards.find((c: Card) => c.text === deletedCardText)?.id;
+
+    unLikeCard(id).then(() => {
+      setSelectedCards((selectedCards: any) => {
+        return selectedCards.filter(
+          (card: Card) => card.text !== deletedCardText
+        );
+      });
     });
   }
 
   function submitAnswer() {
-    window.location.href = `/results`;
+    finishSelecting().then(() => {
+      window.location.href = `/results`;
+    });
   }
   return (
     <Container size="xs" className={styles.container}>

--- a/web/src/hooks/useSocketContext.tsx
+++ b/web/src/hooks/useSocketContext.tsx
@@ -1,13 +1,16 @@
 import { useEffect, useState, createContext } from 'react';
 import { io, Socket } from 'socket.io-client';
 
-const SocketContext = createContext<any>(null);
+const SocketContext = createContext<{
+  state: Lobby | undefined;
+  socket: Socket;
+}>(null as any);
 
 interface Lobby {
   code: string;
   createdAt: string;
   updatedAt: string;
-  currentRound: object;
+  currentRound: { id: string };
   id: string;
   title: string;
 }
@@ -16,7 +19,7 @@ const SocketProvider = ({ children }: { children: JSX.Element }) => {
   const [state, setState] = useState<Lobby | undefined>(undefined);
   let socket: Socket = null as unknown as Socket;
   useEffect(() => {
-    socket = io('http://localhost:8000', {
+    socket = io('', {
       transports: ['websocket'],
       path: '/lobby/',
       auth: { token: localStorage.getItem('accessTokenAtos') }

--- a/web/src/pages/admin/GameView/ActiveGame.tsx
+++ b/web/src/pages/admin/GameView/ActiveGame.tsx
@@ -1,11 +1,11 @@
 import { List, Tabs } from '@mantine/core';
 import { useContext } from 'react';
 import { GameContext } from './contexts/GameProvider';
-import { Player } from '../../../api/models/Player';
+import { Player } from '../../../api/models';
 import { PlayerView } from '../../../components/PlayerAvatar/PlayerView';
 
 export function ActiveGame() {
-  const { players } = useContext(GameContext);
+  const { players, playerCards } = useContext(GameContext);
 
   return (
     <Tabs
@@ -22,7 +22,13 @@ export function ActiveGame() {
         <List>
           {players.map((player: Player) => {
             // TODO add list of selected cards
-            return <PlayerView player={player} key={player.id} />;
+            return (
+              <PlayerView
+                player={player}
+                key={player.id}
+                cardIds={playerCards[player.id]?.cards || []}
+              />
+            );
           })}
         </List>
       </Tabs.Tab>

--- a/web/src/pages/admin/GameView/contexts/SocketProvider.tsx
+++ b/web/src/pages/admin/GameView/contexts/SocketProvider.tsx
@@ -1,6 +1,6 @@
 import { io, Socket } from 'socket.io-client';
 import { createContext, useEffect, useState } from 'react';
-import { Lobby, Player, Round } from '../../../../api/models';
+import { Lobby, Player, Round, SelectedCards } from '../../../../api/models';
 import { AtosLoadingScreen } from '../../../../components/AtosLoadingScreen/AtosLoadingScreen';
 
 interface Props {
@@ -36,6 +36,7 @@ type ListenEvents = {
   'round.started': (round: Round) => void;
   'round.ended': (round: Round) => void;
   'round.updated': (round: Round) => void;
+  'cards.selected.updated': (selectedCards: SelectedCards) => void;
 };
 
 // These are manually typed send events for type safety.

--- a/web/src/pages/admin/GameView/contexts/useGameState.ts
+++ b/web/src/pages/admin/GameView/contexts/useGameState.ts
@@ -1,7 +1,5 @@
 import { useState } from 'react';
-import { Lobby } from '../../../../api/models/Lobby';
-import { Player } from '../../../../api/models/Player';
-import { Round } from '../../../../api/models/Round';
+import { Round, Player, Lobby, SelectedCards } from '../../../../api/models';
 
 type State = {
   loading: true;
@@ -19,6 +17,9 @@ export function useGameState() {
   const [state, setState] = useState<State | LoadedState>({
     loading: true
   });
+  const [playerCards, setPlayerCards] = useState<{
+    [key: string]: SelectedCards;
+  }>({});
 
   const updateRound = (round: Round) =>
     setState(
@@ -52,5 +53,20 @@ export function useGameState() {
       } as unknown as LoadedState;
     });
 
-  return { state, updateRound, addPlayer, onLoad, addCard };
+  const updateSPC = (selectedCards: SelectedCards) => {
+    setPlayerCards((playerCards) => ({
+      ...playerCards,
+      [selectedCards.playerId]: selectedCards
+    }));
+  };
+
+  return {
+    state,
+    updateRound,
+    addPlayer,
+    onLoad,
+    addCard,
+    updateSPC,
+    playerCards
+  };
 }


### PR DESCRIPTION
- Add display for viewing the cards a player has selected as an admin.
- Implement api calls on card like and unlike events, as well as finish selecting actions by the player.
- Implement guards and roles for the selected cards endpoints.

The cards will dynamically update on the admin view: (I didn't pay attention to proper styling)
![image](https://user-images.githubusercontent.com/56258608/168308569-bab29372-ba22-4dae-88df-bd61c280d0af.png)
